### PR TITLE
#2 Fixed a crash when trying to update a row where nothing changed

### DIFF
--- a/vendor/Flannel/Core/Db/Row.php
+++ b/vendor/Flannel/Core/Db/Row.php
@@ -60,7 +60,8 @@ abstract class Row extends \Flannel\Core\BaseObject {
                 $id = $this->_dbTable->insertRow($this->getAllData());
                 $this->setId($id);
             } else {
-                $this->_dbTable->updateRow($this->getId(), $this->getChangedData());
+				if(!empty($this->getChangedData()))
+					$this->_dbTable->updateRow($this->getId(), $this->getChangedData());
             }
             $data = $this->_dbTable->getRow($this->getId());
             $this->addData($data);


### PR DESCRIPTION
Fixes issue #2 by checking whether changedData is empty before running the SQL update